### PR TITLE
feat(http): apply similar schema complexity limits to dynamic payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/stoplightio/prism.git"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "lint": "eslint ./packages/**/src/*.ts",
     "lint.fix": "yarn lint --fix",
     "clean": "rm -rf ./packages/**/dist ./packages/**/*.tsbuildinfo",
@@ -61,6 +62,7 @@
     "lodash": "^4.17.21",
     "nock": "^13.1.3",
     "node-fetch": "^2.6.7",
+    "patch-package": "^8.0.0",
     "prettier": "^2.4.1",
     "split2": "^3.2.2",
     "tmp": "^0.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "fp-ts": "^2.11.5",
-    "json-schema-faker": "0.5.3",
+    "json-schema-faker": "0.5.6",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "pino": "^6.13.3",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -35,7 +35,7 @@
     "fp-ts": "^2.11.5",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
-    "json-schema-faker": "0.5.3",
+    "json-schema-faker": "0.5.6",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "parse-multipart-data": "^1.5.0",

--- a/patches/json-schema-faker+0.5.6.patch
+++ b/patches/json-schema-faker+0.5.6.patch
@@ -1,0 +1,303 @@
+diff --git a/node_modules/json-schema-faker/dist/main.cjs b/node_modules/json-schema-faker/dist/main.cjs
+index 2951f8c..d39d034 100644
+--- a/node_modules/json-schema-faker/dist/main.cjs
++++ b/node_modules/json-schema-faker/dist/main.cjs
+@@ -2278,139 +2278,155 @@ function getMeta({ $comment: comment, title, description }) {
+     return memo;
+   }, {});
+ }
+-function traverse(schema, path, resolve2, rootSchema) {
+-  schema = resolve2(schema, null, path);
+-  if (schema && (schema.oneOf || schema.anyOf || schema.allOf)) {
++function createTraverse(ticks) {
++  return function traverse(schema, path, resolve2, rootSchema) {
++    if (ticks > 0) {
++      ticks--;
++    }
++
++    if (ticks === 0) {
++      throw new RangeError(`Schema size exceeded`)
++    }
++
+     schema = resolve2(schema, null, path);
+-  }
+-  if (!schema) {
+-    throw new Error(`Cannot traverse at '${path.join(".")}', given '${JSON.stringify(rootSchema)}'`);
+-  }
+-  const context = {
+-    ...getMeta(schema),
+-    schemaPath: path
+-  };
+-  if (path[path.length - 1] !== "properties") {
+-    if (option_default("useExamplesValue") && Array.isArray(schema.examples)) {
+-      const fixedExamples = schema.examples.concat("default" in schema ? [schema.default] : []);
+-      return { value: utils_default.typecast(null, schema, () => random_default.pick(fixedExamples)), context };
++    if (schema && (schema.oneOf || schema.anyOf || schema.allOf)) {
++      schema = resolve2(schema, null, path);
+     }
+-    if (option_default("useExamplesValue") && typeof schema.example !== "undefined") {
+-      return { value: utils_default.typecast(null, schema, () => schema.example), context };
++    if (!schema) {
++      throw new Error(`Cannot traverse at '${path.join(".")}', given '${JSON.stringify(rootSchema)}'`);
+     }
+-    if (option_default("useDefaultValue") && "default" in schema) {
+-      if (schema.default !== "" || !option_default("replaceEmptyByRandomValue")) {
+-        return { value: schema.default, context };
++    const context = {
++      ...getMeta(schema),
++      schemaPath: path
++    };
++    if (path[path.length - 1] !== "properties") {
++      if (option_default("useExamplesValue") && Array.isArray(schema.examples)) {
++        const fixedExamples = schema.examples.concat("default" in schema ? [schema.default] : []);
++        return {value: utils_default.typecast(null, schema, () => random_default.pick(fixedExamples)), context};
++      }
++      if (option_default("useExamplesValue") && typeof schema.example !== "undefined") {
++        return {value: utils_default.typecast(null, schema, () => schema.example), context};
++      }
++      if (option_default("useDefaultValue") && "default" in schema) {
++        if (schema.default !== "" || !option_default("replaceEmptyByRandomValue")) {
++          return {value: schema.default, context};
++        }
++      }
++      if ("template" in schema) {
++        return {value: utils_default.template(schema.template, rootSchema), context};
++      }
++      if ("const" in schema) {
++        return {value: schema.const, context};
+       }
+     }
+-    if ("template" in schema) {
+-      return { value: utils_default.template(schema.template, rootSchema), context };
++    if (schema.not && typeof schema.not === "object") {
++      schema = utils_default.notValue(schema.not, utils_default.omitProps(schema, ["not"]));
++      if (schema.type && schema.type === "object") {
++        const {value, context: innerContext} = traverse(schema, path.concat(["not"]), resolve2, rootSchema);
++        return {value: utils_default.clean(value, schema, false), context: {...context, items: innerContext}};
++      }
+     }
+-    if ("const" in schema) {
+-      return { value: schema.const, context };
++    if (typeof schema.thunk === "function") {
++      const {value, context: innerContext} = traverse(schema.thunk(rootSchema), path, resolve2);
++      return {value, context: {...context, items: innerContext}};
+     }
+-  }
+-  if (schema.not && typeof schema.not === "object") {
+-    schema = utils_default.notValue(schema.not, utils_default.omitProps(schema, ["not"]));
+-    if (schema.type && schema.type === "object") {
+-      const { value, context: innerContext } = traverse(schema, path.concat(["not"]), resolve2, rootSchema);
+-      return { value: utils_default.clean(value, schema, false), context: { ...context, items: innerContext } };
++    if (schema.jsonPath) {
++      return {value: schema, context};
+     }
+-  }
+-  if (typeof schema.thunk === "function") {
+-    const { value, context: innerContext } = traverse(schema.thunk(rootSchema), path, resolve2);
+-    return { value, context: { ...context, items: innerContext } };
+-  }
+-  if (schema.jsonPath) {
+-    return { value: schema, context };
+-  }
+-  let type = schema.type;
+-  if (Array.isArray(type)) {
+-    type = random_default.pick(type);
+-  } else if (typeof type === "undefined") {
+-    type = infer_default(schema, path) || type;
+-    if (type) {
+-      schema.type = type;
++    let type = schema.type;
++    if (Array.isArray(type)) {
++      type = random_default.pick(type);
++    } else if (typeof type === "undefined") {
++      type = infer_default(schema, path) || type;
++      if (type) {
++        schema.type = type;
++      }
+     }
+-  }
+-  if (typeof schema.generate === "function") {
+-    const retVal = utils_default.typecast(null, schema, () => schema.generate(rootSchema, path));
+-    const retType = retVal === null ? "null" : typeof retVal;
+-    if (retType === type || retType === "number" && type === "integer" || Array.isArray(retVal) && type === "array") {
+-      return { value: retVal, context };
++    if (typeof schema.generate === "function") {
++      const retVal = utils_default.typecast(null, schema, () => schema.generate(rootSchema, path));
++      const retType = retVal === null ? "null" : typeof retVal;
++      if (retType === type || retType === "number" && type === "integer" || Array.isArray(retVal) && type === "array") {
++        return {value: retVal, context};
++      }
+     }
+-  }
+-  if (typeof schema.pattern === "string") {
+-    return { value: utils_default.typecast("string", schema, () => random_default.randexp(schema.pattern)), context };
+-  }
+-  if (Array.isArray(schema.enum)) {
+-    return { value: utils_default.typecast(null, schema, () => random_default.pick(schema.enum)), context };
+-  }
+-  if (typeof type === "string") {
+-    if (!types_default[type]) {
+-      if (option_default("failOnInvalidTypes")) {
+-        throw new error_default(`unknown primitive ${utils_default.short(type)}`, path.concat(["type"]));
++    if (typeof schema.pattern === "string") {
++      return {value: utils_default.typecast("string", schema, () => random_default.randexp(schema.pattern)), context};
++    }
++    if (Array.isArray(schema.enum)) {
++      return {value: utils_default.typecast(null, schema, () => random_default.pick(schema.enum)), context};
++    }
++    if (typeof type === "string") {
++      if (!types_default[type]) {
++        if (option_default("failOnInvalidTypes")) {
++          throw new error_default(`unknown primitive ${utils_default.short(type)}`, path.concat(["type"]));
++        } else {
++          const value = option_default("defaultInvalidTypeProduct");
++          if (typeof value === "string" && types_default[value]) {
++            return {value: types_default[value](schema, path, resolve2, traverse), context};
++          }
++          return {value, context};
++        }
+       } else {
+-        const value = option_default("defaultInvalidTypeProduct");
+-        if (typeof value === "string" && types_default[value]) {
+-          return { value: types_default[value](schema, path, resolve2, traverse), context };
++        try {
++          const innerResult = types_default[type](schema, path, resolve2, traverse);
++          if (type === "array") {
++            return {
++              value: innerResult.map(({value}) => value),
++              context: {
++                ...context,
++                items: innerResult.map(
++                  Array.isArray(schema.items) ? ({context: c}) => c : ({context: c}) => ({
++                    ...c,
++                    // we have to remove the index from the path to get the real schema path
++                    schemaPath: c.schemaPath.slice(0, -1)
++                  })
++                )
++              }
++            };
++          }
++          if (type === "object") {
++            return innerResult !== null ? {
++              value: innerResult.value,
++              context: {...context, items: innerResult.context}
++            } : {value: {}, context};
++          }
++          return {value: innerResult, context};
++        } catch (e) {
++          if (e instanceof RangeError) {
++            throw e;
++          }
++          if (typeof e.path === "undefined") {
++            throw new error_default(e.stack, path);
++          }
++          throw e;
+         }
+-        return { value, context };
+       }
+-    } else {
+-      try {
+-        const innerResult = types_default[type](schema, path, resolve2, traverse);
+-        if (type === "array") {
+-          return {
+-            value: innerResult.map(({ value }) => value),
+-            context: {
+-              ...context,
+-              items: innerResult.map(
+-                Array.isArray(schema.items) ? ({ context: c }) => c : ({ context: c }) => ({
+-                  ...c,
+-                  // we have to remove the index from the path to get the real schema path
+-                  schemaPath: c.schemaPath.slice(0, -1)
+-                })
+-              )
+-            }
+-          };
+-        }
+-        if (type === "object") {
+-          return innerResult !== null ? { value: innerResult.value, context: { ...context, items: innerResult.context } } : { value: {}, context };
+-        }
+-        return { value: innerResult, context };
+-      } catch (e) {
+-        if (typeof e.path === "undefined") {
+-          throw new error_default(e.stack, path);
++    }
++    let valueCopy = {};
++    let contextCopy = {...context};
++    if (Array.isArray(schema)) {
++      valueCopy = [];
++    }
++    const pruneProperties = option_default("pruneProperties") || [];
++    Object.keys(schema).forEach((prop) => {
++      if (pruneProperties.includes(prop))
++        return;
++      if (schema[prop] === null)
++        return;
++      if (typeof schema[prop] === "object" && prop !== "definitions") {
++        const {value, context: innerContext} = traverse(schema[prop], path.concat([prop]), resolve2, valueCopy);
++        valueCopy[prop] = utils_default.clean(value, schema[prop], false);
++        contextCopy[prop] = innerContext;
++        if (valueCopy[prop] === null && option_default("omitNulls")) {
++          delete valueCopy[prop];
++          delete contextCopy[prop];
+         }
+-        throw e;
++      } else {
++        valueCopy[prop] = schema[prop];
+       }
+-    }
+-  }
+-  let valueCopy = {};
+-  let contextCopy = { ...context };
+-  if (Array.isArray(schema)) {
+-    valueCopy = [];
++    });
++    return {value: valueCopy, context: contextCopy};
+   }
+-  const pruneProperties = option_default("pruneProperties") || [];
+-  Object.keys(schema).forEach((prop) => {
+-    if (pruneProperties.includes(prop))
+-      return;
+-    if (schema[prop] === null)
+-      return;
+-    if (typeof schema[prop] === "object" && prop !== "definitions") {
+-      const { value, context: innerContext } = traverse(schema[prop], path.concat([prop]), resolve2, valueCopy);
+-      valueCopy[prop] = utils_default.clean(value, schema[prop], false);
+-      contextCopy[prop] = innerContext;
+-      if (valueCopy[prop] === null && option_default("omitNulls")) {
+-        delete valueCopy[prop];
+-        delete contextCopy[prop];
+-      }
+-    } else {
+-      valueCopy[prop] = schema[prop];
+-    }
+-  });
+-  return { value: valueCopy, context: contextCopy };
+ }
+ var traverse_default;
+ var init_traverse = __esm({
+@@ -2421,7 +2437,7 @@ var init_traverse = __esm({
+     init_infer();
+     init_types();
+     init_option();
+-    traverse_default = traverse;
++    traverse_default = createTraverse;
+   }
+ });
+ 
+@@ -2611,6 +2627,7 @@ function run(refs, schema, container2, synchronous) {
+   }
+   const refDepthMin = option_default("refDepthMin") || 0;
+   const refDepthMax = option_default("refDepthMax") || 3;
++  const ticks = option_default("ticks") ?? -1;
+   try {
+     const { resolveSchema } = buildResolveSchema_default({
+       refs,
+@@ -2620,7 +2637,7 @@ function run(refs, schema, container2, synchronous) {
+       refDepthMin,
+       refDepthMax
+     });
+-    const result = traverse_default(utils_default.clone(schema), [], resolveSchema);
++    const result = traverse_default(ticks)(utils_default.clone(schema), [], resolveSchema);
+     if (option_default("resolveJsonPath")) {
+       return {
+         value: resolve(result.value),

--- a/test-harness/specs/generated-responses/too_complex-AC-2.oas3.txt
+++ b/test-harness/specs/generated-responses/too_complex-AC-2.oas3.txt
@@ -1,0 +1,26 @@
+====test====
+When requesting a schema that is too complex for JSON Schema Faker,
+I expect a 500 problem detail response.
+====spec====
+openapi: 3.0.2
+paths:
+  /todos:
+    get:
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                minItems: 3000
+====server====
+mock -p 4010 ${document} --dynamic
+====command====
+curl -i http://localhost:4010/todos
+====expect====
+HTTP/1.1 500 Internal Server Error
+
+{"type":"SCHEMA_TOO_COMPLEX","title":"Schema too complex","status":500,"detail":"Unable to generate body for response. The schema is too complex to generate."}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,6 +1815,11 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atomic-sleep@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz"
@@ -2053,14 +2058,16 @@ cacache@^18.0.0:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz"
-  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4, call-bind@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
   dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.1"
-    set-function-length "^1.1.1"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 call-me-maybe@^1.0.1:
   version "1.0.2"
@@ -2161,7 +2168,7 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-ci-info@^3.2.0, ci-info@^3.6.1:
+ci-info@^3.2.0, ci-info@^3.6.1, ci-info@^3.7.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
@@ -2536,17 +2543,10 @@ dateformat@^4.6.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@4, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.3, debug@^4.3.4:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -2611,14 +2611,14 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-data-property@^1.0.1, define-data-property@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz"
-  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+define-data-property@^1.0.1, define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
   dependencies:
-    get-intrinsic "^1.2.1"
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
@@ -2835,6 +2835,18 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-get-iterator@^1.1.1:
   version "1.1.3"
@@ -3214,6 +3226,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.2.0"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz"
@@ -3317,6 +3336,16 @@ fs-extra@^11.1.0, fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -3394,11 +3423,12 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz"
-  integrity sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
+  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
   dependencies:
+    es-errors "^1.3.0"
     function-bind "^1.1.2"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
@@ -3617,12 +3647,12 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-property-descriptors@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz"
-  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -4149,7 +4179,7 @@ is-weakset@^2.0.1:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -4695,10 +4725,10 @@ json-schema-compare@^0.2.2:
   dependencies:
     lodash "^4.17.4"
 
-json-schema-faker@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.3.tgz"
-  integrity sha512-BeIrR0+YSrTbAR9dOMnjbFl1MvHyXnq+Wpdw1FpWZDHWKLzK229hZ5huyPcmzFUfVq1ODwf40WdGVoE266UBUg==
+json-schema-faker@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.6.tgz#731e5a8616bf2b4b53206a6ae18578a5fccc43a5"
+  integrity sha512-u/cFC26/GDxh2vPiAC8B8xVvpXAW+QYtG2mijEbKrimCk8IHtiwQBjCE8TwvowdhALWq9IcdIWZ+/8ocXvdL3Q==
   dependencies:
     json-schema-ref-parser "^6.1.0"
     jsonpath-plus "^7.2.0"
@@ -4726,6 +4756,16 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json-stable-stringify@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz#52d4361b47d49168bcc4e564189a42e5a7439454"
+  integrity sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==
+  dependencies:
+    call-bind "^1.0.5"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
 
 json-stringify-safe@^5.0.1:
   version "5.0.1"
@@ -4756,6 +4796,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
+
 jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -4777,6 +4822,13 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -5780,6 +5832,14 @@ ono@^4.0.11:
   dependencies:
     format-util "^1.0.3"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -6015,6 +6075,27 @@ parse-url@^8.1.0:
   integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
   dependencies:
     parse-path "^7.0.0"
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -6563,6 +6644,13 @@ rfdc@^1.3.0:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -6648,7 +6736,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.5.4, semver@^7.2.1, semver@^7.3.2, semver@^7.5.3, semver@^7.5.4:
+semver@7.5.4:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -6660,7 +6748,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
+semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
   integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
@@ -6670,15 +6758,17 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz"
-  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+set-function-length@^1.1.1, set-function-length@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
   dependencies:
-    define-data-property "^1.1.1"
-    get-intrinsic "^1.2.1"
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
     gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
+    has-property-descriptors "^1.0.2"
 
 set-function-name@^2.0.0:
   version "2.0.1"
@@ -6773,6 +6863,11 @@ slash@3.0.0, slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -6981,7 +7076,7 @@ string-length@^4.0.1:
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -7031,7 +7126,7 @@ stringify-object@^3.3.0:
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
@@ -7286,15 +7381,10 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
+tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
-
-tslib@^2.2.0, tslib@^2.3.1, tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
@@ -7683,7 +7773,7 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -7781,6 +7871,11 @@ yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.2.2:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e"
+  integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
 
 yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
**Summary**

Static response generator that uses [stoplight/json-schema-sampler](https://github.com/stoplightio/json-schema-sampler) has a [built-in](https://github.com/stoplightio/json-schema-sampler/pull/22) configurable limit.
It's currently set it to 2500 over here.

This PR adds a similar option to dynamic responses, also set to 2500.
I decided not to fork json-schema-faker and rather apply a patch with the change.
I also bumped json-schema-faker to the latest version.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
