### PR TITLE
feat(http-server): support delays

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "split2": "^3.2.2",
     "tmp": "^0.2.0",
     "ts-jest": "^29.1.1",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.2",
     "ts-transform-import-path-rewrite": "^0.3.0",
     "tsconfig-paths": "^4.1.0",
     "ttypescript": "^1.5.15",

--- a/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
+++ b/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
@@ -128,6 +128,18 @@ describe('getHttpConfigFromRequest()', () => {
           )
         );
       });
+
+      test('validates delay is smaller than or equal to 5000', () => {
+        assertLeft(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=5001' } }), error =>
+          expect(error.name).toEqual(
+            'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+          )
+        );
+
+        assertRight(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=5000' } }), parsed =>
+          expect(parsed).toHaveProperty('delay', 5000)
+        );
+      });
     });
   });
 });

--- a/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
+++ b/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
@@ -30,7 +30,10 @@ describe('getHttpConfigFromRequest()', () => {
           getHttpConfigFromRequest({
             url: { path: '/', query: { __code: 'default' } },
           }),
-          error => expect(error.name).toEqual('https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity')
+          error =>
+            expect(error.name).toEqual(
+              'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+            )
         );
       });
 
@@ -54,13 +57,27 @@ describe('getHttpConfigFromRequest()', () => {
         );
       });
 
-      test('validates code is a number', () => {
-        return assertLeft(
+      test('validates code is a valid http status', () => {
+        assertLeft(
           getHttpConfigFromRequest({
             url: { path: '/' },
             headers: { prefer: 'code=default' },
           }),
-          error => expect(error.name).toEqual('https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity')
+          error =>
+            expect(error.name).toEqual(
+              'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+            )
+        );
+
+        assertLeft(
+          getHttpConfigFromRequest({
+            url: { path: '/' },
+            headers: { prefer: 'code=500000' },
+          }),
+          error =>
+            expect(error.name).toEqual(
+              'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+            )
         );
       });
 
@@ -85,6 +102,30 @@ describe('getHttpConfigFromRequest()', () => {
             headers: { prefer: 'dynamic=true' },
           }),
           parsed => expect(parsed).toHaveProperty('dynamic', true)
+        );
+      });
+
+      test('extracts delay', () => {
+        assertRight(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=100' } }), parsed =>
+          expect(parsed).toHaveProperty('delay', 100)
+        );
+
+        assertRight(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=0' } }), parsed =>
+          expect(parsed).toHaveProperty('delay', 0)
+        );
+      });
+
+      test('validates delay is a non-negative number', () => {
+        assertLeft(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=bear' } }), error =>
+          expect(error.name).toEqual(
+            'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+          )
+        );
+
+        assertLeft(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'delay=-100' } }), error =>
+          expect(error.name).toEqual(
+            'https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity'
+          )
         );
       });
     });

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -23,7 +23,7 @@ const PreferencesDecoder = D.partial({
   delay: pipe(
     D.string,
     IntegerFromString,
-    D.refine((n): n is number => n >= 0, 'a positive integer')
+    D.refine((n): n is number => n >= 0 && n <= 5000, 'a positive integer smaller than or equal to 5000')
   ),
   dynamic: pipe(D.string, BooleanFromString),
   example: D.string,

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -11,6 +11,7 @@ export type PrismHttpComponents = IPrismComponents<IHttpOperation, IHttpRequest,
 export interface IHttpOperationConfig {
   mediaTypes?: string[];
   code?: number;
+  delay?: number;
   exampleKey?: string;
   dynamic: boolean;
   ignoreExamples?: boolean;

--- a/test-harness/specs/delay/delay_negative.txt
+++ b/test-harness/specs/delay/delay_negative.txt
@@ -1,0 +1,34 @@
+====test====
+When I send a request to an operation
+And in the headers I specify `Prefer: delay=-5`
+Then I get back a response with a status code of 422
+====spec====
+openapi: "3.0.4"
+info:
+  version: "0"
+  title: Delays test
+  description: Delays test
+paths:
+  /widget:
+    get:
+      description: widget details
+      operationId: widgetDetails
+      responses:
+        "200":
+          description: widget details response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    default: "Super Widget"
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i http://localhost:4010/widget -H "Prefer: delay=-5"
+====expect-loose====
+HTTP/1.1 422 Unprocessable Entity
+
+{"type":"https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity","title":"Invalid request.","status":422,"detail":"optional property \"delay\"\n└─ cannot decode -5, should be a positive integer"}

--- a/test-harness/specs/delay/delay_negative.txt
+++ b/test-harness/specs/delay/delay_negative.txt
@@ -28,7 +28,7 @@ paths:
 mock -p 4010 ${document}
 ====command====
 curl -i http://localhost:4010/widget -H "Prefer: delay=-5"
-====expect-loose====
+====expect====
 HTTP/1.1 422 Unprocessable Entity
 
-{"type":"https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity","title":"Invalid request.","status":422,"detail":"optional property \"delay\"\n└─ cannot decode -5, should be a positive integer"}
+{"type":"https://www.getambassador.io/docs/blackbird/latest/reference/mock-server-errors#unprocessable_entity","title":"Invalid request.","status":422,"detail":"optional property \"delay\"\n└─ cannot decode -5, should be a positive integer smaller than or equal to 5000"}

--- a/test-harness/specs/delay/delay_positive.txt
+++ b/test-harness/specs/delay/delay_positive.txt
@@ -1,0 +1,30 @@
+====test====
+When I send a request to an operation
+And in the headers I specify `Prefer: delay=500`
+Then I get back a response with a delay of 500ms
+====spec====
+openapi: "3.0.4"
+info:
+  version: "0"
+  title: Delays test
+  description: Delays test
+paths:
+  /delay:
+    get:
+      description: widget details
+      responses:
+        "200":
+          description: delay response
+          content:
+            application/json:
+              schema:
+                type: integer
+                default: 0
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -s -w "%{time_total}" -H "Prefer: delay=500" "http://127.0.0.1:4010/delay" | awk '{gsub(/0([0-9]+\.[0-9]+)/, ($1 * 1000 > 500 ? "Value is higher than 500" : "Value is not higher than 500")); print}'
+====expect-loose====
+HTTP/1.1 200 OK
+
+Value is higher than 500

--- a/test-harness/specs/delay/delay_zero.txt
+++ b/test-harness/specs/delay/delay_zero.txt
@@ -1,0 +1,30 @@
+====test====
+When I send a request to an operation
+And in the headers I specify `Prefer: delay=0`
+Then I get a response without any delay
+====spec====
+openapi: "3.0.4"
+info:
+  version: "0"
+  title: Delays test
+  description: Delays test
+paths:
+  /delay:
+    get:
+      description: widget details
+      responses:
+        "200":
+          description: delay response
+          content:
+            application/json:
+              schema:
+                type: integer
+                default: 0
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -s -w "%{time_total}" -H "Prefer: delay=0" "http://127.0.0.1:4010/delay" | awk '{gsub(/0([0-9]+\.[0-9]+)/, ($1 * 1000 < 100  ? "Value is lower than 100" : "Value is higher than 100")); print}'
+====expect-loose====
+HTTP/1.1 200 OK
+
+Value is lower than 100

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,6 +327,13 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz"
@@ -600,10 +607,10 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.1.0":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
-  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
@@ -614,6 +621,14 @@
   version "1.4.15"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
@@ -1243,6 +1258,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@tufjs/canonical-json@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz#eade9fd1f537993bc1f0949f3aea276ecc4fab31"
@@ -1632,10 +1667,22 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -6977,14 +7024,6 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.17:
-  version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
@@ -7365,16 +7404,23 @@ ts-jest@^29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 ts-transform-import-path-rewrite@^0.3.0:
@@ -7603,6 +7649,11 @@ uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"


### PR DESCRIPTION

**Summary**

This PR adds support for an extra property `delay` in `Prefer` header that let user delay a response.
I considered adding a new header for that purpose, but eventually decided not to.
I also didn't want to name it `wait` as the purpose of it is not quite the same.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A


