### PR TITLE
feat: support error rate 

### DIFF
--- a/packages/cli/src/util/__tests__/config.spec.ts
+++ b/packages/cli/src/util/__tests__/config.spec.ts
@@ -1,0 +1,78 @@
+import { assertValidConfig, type Config } from '../config';
+
+describe('assertValidConfig', () => {
+  it('should not throw an error for a valid config', () => {
+    const validConfig: Config = {
+      ignoreExamples: true,
+      dynamic: false,
+      jsonSchemaFakerFillProperties: true,
+      chaos: {
+        enabled: true,
+        rate: 50,
+        codes: [500, 502],
+      },
+    };
+
+    expect(assertValidConfig.bind(null, validConfig)).not.toThrow();
+  });
+
+  it('should throw an error for an invalid config', () => {
+    const invalidConfig = {
+      ignoreExamples: 'true', // invalid type
+      dynamic: false,
+      jsonSchemaFakerFillProperties: true,
+      chaos: {
+        enabled: true,
+        rate: 50,
+        codes: [500, 502],
+      },
+    };
+
+    expect(assertValidConfig.bind(null, invalidConfig)).toThrow();
+  });
+
+  it('should throw an error for a config with missing required properties', () => {
+    const invalidConfig = {
+      dynamic: false,
+      jsonSchemaFakerFillProperties: true,
+      chaos: {
+        enabled: true,
+        rate: 50,
+      },
+    };
+
+    expect(assertValidConfig.bind(null, invalidConfig)).toThrow();
+  });
+
+  it('should throw an error for a config with additional properties', () => {
+    const invalidConfig = {
+      ignoreExamples: true,
+      dynamic: false,
+      jsonSchemaFakerFillProperties: true,
+      extraProperty: 'not allowed',
+    };
+
+    expect(assertValidConfig.bind(null, invalidConfig)).toThrow();
+  });
+
+  it('should throw an error for a config with enabled chaos and no/empty codes', () => {
+    expect(
+      assertValidConfig.bind(null, {
+        chaos: {
+          enabled: true,
+          rate: 50,
+        },
+      })
+    ).toThrow();
+
+    expect(
+      assertValidConfig.bind(null, {
+        chaos: {
+          enabled: true,
+          rate: 50,
+          codes: [],
+        },
+      })
+    ).toThrow();
+  });
+});

--- a/packages/cli/src/util/config.ts
+++ b/packages/cli/src/util/config.ts
@@ -1,10 +1,29 @@
 import { promises as fs } from 'fs';
-import * as Ajv from 'ajv';
+import * as Ajv from 'ajv/dist/2020';
 import type * as pino from 'pino';
 import type { CreateMockServerOptions } from './createServer';
 import type { Observable } from './observable';
 
-const ajv = new Ajv.Ajv({
+export type Config = {
+  ignoreExamples?: boolean;
+  dynamic?: boolean;
+  jsonSchemaFakerFillProperties?: boolean;
+  chaos?: {
+    enabled?: boolean;
+    rate?: number;
+    codes?: number[];
+  } & (
+    | {
+        enabled: true;
+        codes: [number, ...number[]];
+      }
+    | {
+        enabled?: false;
+      }
+  );
+};
+
+const ajv = new Ajv.Ajv2020({
   strict: true,
   allErrors: true,
 });
@@ -15,9 +34,53 @@ const validate = ajv.compile({
     ignoreExamples: { type: 'boolean' },
     dynamic: { type: 'boolean' },
     jsonSchemaFakerFillProperties: { type: 'boolean' },
-  } satisfies Partial<Record<keyof CreateMockServerOptions, unknown>>,
+    chaos: {
+      type: 'object',
+      unevaluatedProperties: false,
+      properties: {
+        enabled: { type: 'boolean' },
+        rate: {
+          type: 'number',
+          minimum: 0,
+          maximum: 100,
+        },
+        codes: {
+          type: 'array',
+          items: {
+            type: 'integer',
+            minimum: 400,
+            exclusiveMaximum: 600,
+          },
+          uniqueItems: true,
+        },
+      },
+      oneOf: [
+        {
+          properties: {
+            enabled: { const: true },
+            codes: {
+              type: 'array',
+              minItems: 1,
+            },
+          },
+          required: ['enabled', 'codes'],
+        },
+        {
+          properties: {
+            enabled: { const: false },
+          },
+        },
+      ],
+    },
+  } satisfies Partial<Record<keyof Config, unknown>>,
   additionalProperties: false,
 });
+
+export function assertValidConfig(input: unknown): asserts input is Config {
+  if (!validate(input)) {
+    throw new Error(ajv.errorsText(validate.errors));
+  }
+}
 
 export async function safeApplyConfig(
   logInstance: pino.Logger,

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -86,6 +86,22 @@ export function findResponseByStatusCode(
   );
 }
 
+export function findResponseByStatusCodes(
+  httpResponses: IHttpOperationResponse[],
+  statusCodes: NEA.NonEmptyArray<number>
+): O.Option<IHttpOperationResponse> {
+  const [first, ...others] = statusCodes;
+
+  return others.reduce(
+    (previous, current) =>
+      pipe(
+        previous,
+        O.alt(() => findResponseByStatusCode(httpResponses, current))
+      ),
+    findResponseByStatusCode(httpResponses, first)
+  );
+}
+
 export function findDefaultResponse(
   httpResponses: IHttpOperationResponse[],
   statusCode = 200

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -12,6 +12,18 @@ export interface IHttpOperationConfig {
   mediaTypes?: string[];
   code?: number;
   delay?: number;
+  chaos?: {
+    rate: number;
+  } & (
+    | {
+        enabled: true;
+        codes: [number, ...number[]];
+      }
+    | {
+        enabled: false;
+        codes: number[];
+      }
+  );
   exampleKey?: string;
   dynamic: boolean;
   ignoreExamples?: boolean;

--- a/test-harness/specs/config/chaos.txt
+++ b/test-harness/specs/config/chaos.txt
@@ -1,0 +1,50 @@
+====test====
+Given I mock and specify a config with chaos enabled
+When I send a request to an operation
+Then the config should influence the response
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    const: Odie
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    const: Unauthorized
+
+====config====
+{
+  "chaos": {
+    "enabled": true,
+    "rate": 100,
+    "codes": [401]
+  }
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i http://localhost:4010/pets/2
+====expect====
+HTTP/1.1 401 OK
+content-type: application/json
+
+{"message":"Unauthorized"}

--- a/test-harness/specs/config/chaos_broken.txt
+++ b/test-harness/specs/config/chaos_broken.txt
@@ -1,0 +1,42 @@
+====test====
+Given I mock and specify a broken config
+When I send a request to an operation
+Then the config should not influence the response
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+        "401":
+          description: Unauthorized
+====config====
+{
+    "chaos": {
+      "enabled": true,
+      "rate": 100,
+      "codes": []
+    }
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i http://localhost:4010/pets/2
+====expect====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"name":"string"}

--- a/test-harness/specs/config/chaos_missing_codes.txt
+++ b/test-harness/specs/config/chaos_missing_codes.txt
@@ -1,0 +1,38 @@
+====test====
+Given I mock and specify a missing error code for chaos
+When I send a request to an operation
+Then the response should be blank with that status code
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+====config====
+{
+    "chaos": {
+      "enabled": true,
+      "rate": 100,
+      "codes": [401]
+    }
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i http://localhost:4010/pets/2
+====expect====
+HTTP/1.1 401 Unauthorized
+Content-Length: 0


### PR DESCRIPTION
**Summary**

This adds configurable error rate. I couldn't think of a better name for that option other than `chaos`, so I'm open to suggestions. I'm not a fan of `chaos`, to be frank.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.


