### PR TITLE
feat: support global delay range

### DIFF
--- a/packages/cli/src/util/__tests__/config.spec.ts
+++ b/packages/cli/src/util/__tests__/config.spec.ts
@@ -6,11 +6,20 @@ describe('assertValidConfig', () => {
       ignoreExamples: true,
       dynamic: false,
       jsonSchemaFakerFillProperties: true,
+      delay: [100, 200],
       chaos: {
         enabled: true,
         rate: 50,
         codes: [500, 502],
       },
+    };
+
+    expect(assertValidConfig.bind(null, validConfig)).not.toThrow();
+  });
+
+  it('should accept numeric delay', () => {
+    const validConfig: Config = {
+      delay: 100,
     };
 
     expect(assertValidConfig.bind(null, validConfig)).not.toThrow();
@@ -72,6 +81,22 @@ describe('assertValidConfig', () => {
           rate: 50,
           codes: [],
         },
+      })
+    ).toThrow();
+  });
+
+  it('should require upper latency bound to be higher than lower latency bound', () => {
+    expect(
+      assertValidConfig.bind(null, {
+        delay: [100, 50],
+      })
+    ).toThrow();
+  });
+
+  it('should throw an error for a config with negative delay', () => {
+    expect(
+      assertValidConfig.bind(null, {
+        delay: -100,
       })
     ).toThrow();
   });

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -117,6 +117,9 @@ async function createPrismServerWithLogger(options: Observable<CreateBaseServerO
           )
         );
       },
+      get delay() {
+        return options.delay;
+      },
       get dynamic() {
         return options.dynamic;
       },
@@ -185,6 +188,7 @@ type CreateBaseServerOptions = {
   config?: string;
   dynamic: boolean;
   cors: boolean;
+  delay?: number | [number, number];
   chaos?: {
     enabled?: boolean;
     rate?: number;

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -112,7 +112,16 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
     const delay: E.Either<Error, O.Option<number>> = pipe(
       requestConfig,
-      E.map(config => (config.mock.delay ? O.some(config.mock.delay) : O.none))
+      E.map(config =>
+        pipe(
+          O.fromNullable(config.mock.delay),
+          O.chain(delay =>
+            Array.isArray(delay)
+              ? O.some(Math.floor(Math.random() * (delay[1] - delay[0] + 1) + delay[0]))
+              : O.some(delay)
+          )
+        )
+      )
     );
 
     void pipe(

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -11,7 +11,7 @@ export type PrismHttpComponents = IPrismComponents<IHttpOperation, IHttpRequest,
 export interface IHttpOperationConfig {
   mediaTypes?: string[];
   code?: number;
-  delay?: number;
+  delay?: number | [number, number];
   chaos?: {
     rate: number;
   } & (

--- a/test-harness/specs/config/delay_constant.txt
+++ b/test-harness/specs/config/delay_constant.txt
@@ -1,0 +1,33 @@
+====test====
+Given I mock and specify a constant delay
+When I send a request to an operation
+Then the response should be delayed by that amount
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: integer
+                default: 0
+====config====
+{
+  "delay": 500
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i -s -w "%{time_total}" "http://127.0.0.1:4010/pets/2" | awk '{gsub(/0([0-9]+\.[0-9]+)/, $1 * 1000 > 500 ? "Value is higher than 500" : "Value is not higher than 500"); print}'
+====expect-loose====
+HTTP/1.1 200 OK
+
+Value is higher than 500

--- a/test-harness/specs/config/delay_range.txt
+++ b/test-harness/specs/config/delay_range.txt
@@ -1,0 +1,33 @@
+====test====
+Given I mock and specify a constant delay
+When I send a request to an operation
+Then the response should be delayed by that amount
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: integer
+                default: 0
+====config====
+{
+  "delay": [300, 500]
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i -s -w "%{time_total}" "http://127.0.0.1:4010/pets/2" | awk '{gsub(/0([0-9]+\.[0-9]+)/, $1 * 1000 > 300 ? "Value is higher than 300" : "Value is not higher than 300"); print}'
+====expect-loose====
+HTTP/1.1 200 OK
+
+Value is higher than 300

--- a/test-harness/specs/delay/delay_config.txt
+++ b/test-harness/specs/delay/delay_config.txt
@@ -1,0 +1,35 @@
+====test====
+When I send a request to an operation
+And I have a config with a delay of 2500ms
+And in the headers I specify `Prefer: delay=100`
+Then I get a response with a delay of 100ms
+====spec====
+openapi: "3.1.1"
+info:
+  version: "0"
+  title: Delays test
+  description: Delays test
+paths:
+  /delay:
+    get:
+      description: widget details
+      responses:
+        "200":
+          description: delay response
+          content:
+            application/json:
+              schema:
+                type: integer
+                default: 0
+====config====
+{
+  "delay": 2500
+}
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -s -w "%{time_total}" -H "Prefer: delay=100" "http://127.0.0.1:4010/delay" | awk '{gsub(/0([0-9]+\.[0-9]+)/, ($1 * 1000 < 2500 ? "Value is lower than 2500" : "Value is higher than 2500")); print}'
+====expect-loose====
+HTTP/1.1 200 OK
+
+Value is lower than 2500


### PR DESCRIPTION

**Summary**

This is a small addition to config file to let user specify a global delay - either constant or a range.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

