### PR TITLE
feat: use random status code if negotiation fails

### DIFF
--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -39,6 +39,11 @@ const randomComparator: Ord<number> = {
 const randomSort = <A extends number>(arr: NonEmptyArray<A>): NonEmptyArray<A> =>
   pipe(arr, sort(randomComparator)) as NonEmptyArray<A>;
 
+const randomStatusCode = (statusCodes: NonEmptyArray<number>): number => {
+  const index = Math.floor(Math.random() * statusCodes.length);
+  return statusCodes[index];
+};
+
 const createEmptyResponse = (code: string, headers: IHttpHeaderParam[], mediaTypes: string[]) => {
   return pipe(
     code,
@@ -316,7 +321,7 @@ const helpers = {
               statusCodes =>
                 pipe(
                   helpers.negotiateOptionsForErrorCodes(httpOperation, desiredOptions, statusCodes),
-                  RE.orElse(() => helpers.negotiateEmptyResponse(statusCodes[0]))
+                  RE.orElse(() => helpers.negotiateEmptyResponse(randomStatusCode(statusCodes)))
                 )
             )
           ),

--- a/test-harness/helpers.ts
+++ b/test-harness/helpers.ts
@@ -26,7 +26,7 @@ export const xmlValidator = {
 };
 
 export function parseSpecFile(spec: string) {
-  const regex = /====(server|test|spec|config|command|expect|expect-loose|expect-keysOnly)====\r?\n/gi;
+  const regex = /====(server|test|spec|config|command|script|expect|expect-stdout|expect-loose|expect-keysOnly)====\r?\n/gi;
   const splitted = spec.split(regex);
 
   const testIndex = splitted.findIndex(t => t === 'test');
@@ -34,18 +34,26 @@ export function parseSpecFile(spec: string) {
   const configIndex = splitted.findIndex(t => t === 'config');
   const serverIndex = splitted.findIndex(t => t === 'server');
   const commandIndex = splitted.findIndex(t => t === 'command');
+  const scriptIndex = splitted.findIndex(t => t === 'script');
   const expectIndex = splitted.findIndex(t => t === 'expect');
   const expectLooseIndex = splitted.findIndex(t => t === 'expect-loose');
+  const expectStdoutIndex = splitted.findIndex(t => t === 'expect-stdout');
   const expectKeysOnlyIndex = splitted.findIndex(t => t === 'expect-keysOnly');
+
+  if (expectStdoutIndex !== -1 && (expectIndex !== -1 || expectLooseIndex !== -1 || expectKeysOnlyIndex !== -1)) {
+    throw new Error('Cannot have expect-stdout with expect, expect-loose, or expect-keysOnly');
+  }
 
   return {
     test: splitted[1 + testIndex],
     spec: splitted[1 + specIndex],
     config: configIndex === -1 ? null : splitted[1 + configIndex],
     server: splitted[1 + serverIndex],
-    command: splitted[1 + commandIndex],
-    expect: splitted[1 + expectIndex],
-    expectLoose: splitted[1 + expectLooseIndex],
-    expectKeysOnly: splitted[1 + expectKeysOnlyIndex],
+    command: commandIndex === -1 ? null : splitted[1 + commandIndex],
+    script: scriptIndex === -1 ? null : splitted[1 + scriptIndex],
+    expect: expectIndex === -1 ? null : splitted[1 + expectIndex],
+    expectStdout: expectStdoutIndex === -1 ? null : splitted[1 + expectStdoutIndex],
+    expectLoose: expectLooseIndex === -1 ? null : splitted[1 + expectLooseIndex],
+    expectKeysOnly: expectKeysOnlyIndex === -1 ? null : splitted[1 + expectKeysOnlyIndex],
   };
 }

--- a/test-harness/specs/config/chaos_missing_code_prefers_wildcard.txt
+++ b/test-harness/specs/config/chaos_missing_code_prefers_wildcard.txt
@@ -1,0 +1,52 @@
+====test====
+Given I mock and specify a missing error code for chaos and I have a wildcard response range
+When I send a request to an operation
+Then the response should negotiate the wildcard response range
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+        "4XX":
+          description: A client error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    const: hello
+                required:
+                  - message
+                additionalProperties: false
+====config====
+{
+    "chaos": {
+      "enabled": true,
+      "rate": 100,
+      "codes": [401]
+    }
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====command====
+curl -i http://localhost:4010/pets/2
+====expect====
+HTTP/1.1 401 Unauthorized
+content-type: application/json
+
+{"message":"hello"}

--- a/test-harness/specs/config/chaos_random_missing_codes.txt
+++ b/test-harness/specs/config/chaos_random_missing_codes.txt
@@ -1,0 +1,48 @@
+====test====
+Given I mock and specify missing error codes for chaos
+When I send a request to an operation
+Then the response should be blank with one of the status code
+====spec====
+openapi: "3.1.0"
+info:
+  version: "0.0"
+  title: Config Test
+paths:
+  /pets/{petId}:
+    get:
+      description: Get a pet by ID
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+====config====
+{
+    "chaos": {
+      "enabled": true,
+      "rate": 100,
+      "codes": [401, 404, 500]
+    }
+}
+====server====
+mock -p 4010 --config ${config} ${document}
+====script====
+seenCodes=""
+count=0
+while [ $count -lt 20 ]; do
+  code=$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:4010/pets/2)
+  if ! echo "$seenCodes" | grep -q "$code"; then
+    seenCodes="$seenCodes $code"
+  fi
+  count=$((count + 1))
+done
+
+sortedCodes=$(echo "$seenCodes" | tr ' ' '\n' | sort | tr '\n' ' ')
+echo "$sortedCodes"
+====expect-stdout====
+401 404 500


### PR DESCRIPTION


**Summary**

A (almost) one-liner to ensure we pick a random status code from chaos.codes if none of the codes are defined on the operation. `test-harness/specs/config/chaos_random_missing_codes.txt` illustrates that behavior well.
I also added one extra test to assert we pick a wildcard response if there's on defined.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A


