### PR TITLE
feat(cli): introduce --watch and --watch-strategy flags

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         gcloud auth configure-docker ${{ env.REGISTRY_REGION }}
 
+    - name: Set outputs
+      id: vars
+      run: echo "git_sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Build and Push Docker Image
       uses: docker/build-push-action@v4
       with:
@@ -48,3 +52,4 @@ jobs:
         platforms: linux/amd64
         tags: |
           ${{ env.REGISTRY_REGION }}/${{ env.REGISTRY_PROJECT }}:latest
+          ${{ env.REGISTRY_REGION }}/${{ env.REGISTRY_PROJECT }}:${{ steps.vars.outputs.git_sha_short }}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^29.5.4",
     "@types/json-schema": "^7.0.9",
     "@types/lodash": "^4.14.175",
-    "@types/node": "^13.1.1",
+    "@types/node": "^22.9.4",
     "@types/node-fetch": "2.5.10",
     "@types/pino": "6.3.12",
     "@types/postman-collection": "^3.5.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,6 @@
     "@stoplight/types": "^14.1.0",
     "ajv": "~8.17.1",
     "chalk": "^4.1.2",
-    "chokidar": "^3.5.2",
     "fp-ts": "^2.11.5",
     "json-schema-faker": "0.5.6",
     "lodash": "^4.17.21",
@@ -24,6 +23,7 @@
     "signale": "^1.4.0",
     "split2": "^3.2.2",
     "tslib": "^2.3.1",
+    "web-locks": "^0.0.8",
     "uri-template-lite": "^22.9.0",
     "urijs": "^1.19.11",
     "yargs": "^16.2.0"

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -49,6 +49,8 @@ const mockCommand: CommandModule = {
       port,
       host,
       cors,
+      watch,
+      watchStrategy,
       document,
       errors,
       verboseLevel,
@@ -64,6 +66,8 @@ const mockCommand: CommandModule = {
       port,
       host,
       document,
+      watch,
+      watchStrategy,
       multiprocess,
       errors,
       verboseLevel,
@@ -71,7 +75,13 @@ const mockCommand: CommandModule = {
       jsonSchemaFakerFillProperties,
     } as const;
 
-    await runPrismAndSetupWatcher(createPrism, options);
+    const controller = new AbortController();
+    try {
+      await runPrismAndSetupWatcher(createPrism, options, controller.signal);
+    } catch (e) {
+      controller.abort();
+      throw e;
+    }
   },
 };
 

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -48,6 +48,8 @@ const proxyCommand: CommandModule = {
       'port',
       'document',
       'multiprocess',
+      'watch',
+      'watchStrategy',
       'upstream',
       'errors',
       'validateRequest',
@@ -58,7 +60,13 @@ const proxyCommand: CommandModule = {
     );
 
     const createPrism = p.multiprocess ? createMultiProcessPrism : createSingleProcessPrism;
-    await runPrismAndSetupWatcher(createPrism, p);
+    const controller = new AbortController();
+    try {
+      await runPrismAndSetupWatcher(createPrism, p, controller.signal);
+    } catch (e) {
+      controller.abort();
+      throw e;
+    }
   },
 };
 

--- a/packages/cli/src/commands/sharedOptions.ts
+++ b/packages/cli/src/commands/sharedOptions.ts
@@ -32,6 +32,18 @@ const sharedOptions: Dictionary<Options> = {
     default: process.env.NODE_ENV === 'production',
   },
 
+  watch: {
+    description: 'Watch the file system for changes and restart the server.',
+    boolean: true,
+    default: true,
+  },
+
+  watchStrategy: {
+    choices: ['polling', 'native-dir', 'native-file'],
+    description: 'The strategy to use when watching the file system for changes.',
+    default: 'polling',
+  },
+
   errors: {
     description: 'Specifies whether request/response violations marked as errors will produce an error response',
     required: true,

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpRequest } from '@stoplight/prism-http';
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import * as chalk from 'chalk';
-import * as cluster from 'cluster';
+import cluster from 'cluster';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import * as O from 'fp-ts/Option';
@@ -54,7 +54,7 @@ const createMultiProcessPrism: CreatePrism = async options => {
 
     return createPrismServerWithLogger(options, logInstance).catch((e: Error) => {
       logInstance.fatal(e.message);
-      cluster.worker.kill();
+      cluster.worker?.kill();
       throw e;
     });
   }
@@ -206,6 +206,8 @@ type CreateBaseServerOptions = {
   port: number;
   document: string;
   multiprocess: boolean;
+  watch: boolean;
+  watchStrategy: 'polling' | 'native-dir' | 'native-file';
   errors: boolean;
   verboseLevel: string;
   ignoreExamples: boolean;

--- a/packages/cli/src/util/fsWatcher/__tests__/debounceCallback.spec.ts
+++ b/packages/cli/src/util/fsWatcher/__tests__/debounceCallback.spec.ts
@@ -37,6 +37,18 @@ describe('debounceCallback', () => {
     expect(callback).toHaveBeenCalledWith('test-path');
   });
 
+  it('should track multiple paths separately', () => {
+    const callback = jest.fn();
+    const signal = new AbortController().signal;
+    const debouncedCallback = debounceCallback(callback, signal);
+
+    debouncedCallback('test-path-1');
+    debouncedCallback('test-path-2');
+    jest.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledWith('test-path-1');
+    expect(callback).toHaveBeenCalledWith('test-path-2');
+  });
+
   it('should clear the timeout when the signal is aborted', () => {
     const callback = jest.fn();
     const abortController = new AbortController();

--- a/packages/cli/src/util/fsWatcher/__tests__/debounceCallback.spec.ts
+++ b/packages/cli/src/util/fsWatcher/__tests__/debounceCallback.spec.ts
@@ -1,0 +1,50 @@
+import { debounceCallback } from '../debounceCallback';
+
+jest.mock('node:timers', () => ({
+  setTimeout: jest.fn((cb: Function, timeout: number, ...args: unknown[]) =>
+    globalThis.setTimeout(cb, timeout, ...args)
+  ),
+  clearTimeout: jest.fn(((...args) => globalThis.clearTimeout(...args)) satisfies typeof globalThis.clearTimeout),
+}));
+
+describe('debounceCallback', () => {
+  jest.useFakeTimers();
+
+  it('should call the callback after the specified delay', () => {
+    const callback = jest.fn();
+    const signal = new AbortController().signal;
+    const debouncedCallback = debounceCallback(callback, signal);
+
+    debouncedCallback('test-path');
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledWith('test-path');
+  });
+
+  it('should reset the timer if called again before the delay', () => {
+    const callback = jest.fn();
+    const signal = new AbortController().signal;
+    const debouncedCallback = debounceCallback(callback, signal);
+
+    debouncedCallback('test-path');
+    jest.advanceTimersByTime(300);
+    debouncedCallback('test-path');
+    jest.advanceTimersByTime(300);
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(callback).toHaveBeenCalledWith('test-path');
+  });
+
+  it('should clear the timeout when the signal is aborted', () => {
+    const callback = jest.fn();
+    const abortController = new AbortController();
+    const debouncedCallback = debounceCallback(callback, abortController.signal);
+
+    debouncedCallback('test-path');
+    abortController.abort();
+    jest.advanceTimersByTime(500);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/util/fsWatcher/debounceCallback.ts
+++ b/packages/cli/src/util/fsWatcher/debounceCallback.ts
@@ -1,0 +1,30 @@
+import { setTimeout } from 'node:timers';
+import type { Callback } from './types';
+
+export function debounceCallback(callback: Callback, signal: AbortSignal): Callback {
+  const state = new Map<string, NodeJS.Timeout>();
+  signal.addEventListener(
+    'abort',
+    () => {
+      for (const timeout of state.values()) {
+        clearTimeout(timeout);
+      }
+    },
+    { once: true }
+  );
+
+  return (path: string) => {
+    const timeoutId = state.get(path);
+    if (timeoutId !== void 0) {
+      clearTimeout(timeoutId);
+    }
+
+    state.set(
+      path,
+      setTimeout(() => {
+        callback(path);
+        state.delete(path);
+      }, 500)
+    );
+  };
+}

--- a/packages/cli/src/util/fsWatcher/implementations/__tests__/__helpers__/mkdtemp.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/__tests__/__helpers__/mkdtemp.ts
@@ -1,0 +1,23 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export async function mkdtempWithFiles() {
+  const dir = await mkdtemp(join(tmpdir(), 'spectra-fs-watcher-'));
+
+  await Promise.all([
+    writeFile(join(dir, 'file-1'), 'content'),
+    writeFile(join(dir, 'file-2'), 'content'),
+    mkdir(join(dir, 'dir-1')).then(() =>
+      Promise.all([
+        writeFile(join(dir, 'dir-1', 'file-1'), 'content'),
+        writeFile(join(dir, 'dir-1', 'file-2'), 'content'),
+      ])
+    ),
+  ]);
+
+  return {
+    cwd: dir,
+    files: [join(dir, 'file-1'), join(dir, 'file-2'), join(dir, 'dir-1', 'file-1'), join(dir, 'dir-1', 'file-2')],
+  };
+}

--- a/packages/cli/src/util/fsWatcher/implementations/__tests__/__helpers__/race.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/__tests__/__helpers__/race.ts
@@ -1,0 +1,18 @@
+import * as timers from 'node:timers/promises';
+
+export async function race(maxDuration: number, controller: AbortController, expectation: () => void) {
+  const opts = { signal: controller.signal } as const;
+  await Promise.race([
+    timers.setTimeout(maxDuration, opts).then(() => controller.abort()),
+    (async () => {
+      for await (const _ of timers.setInterval(50, opts)) {
+        try {
+          expectation();
+          break;
+        } catch {
+          // no-op
+        }
+      }
+    })(),
+  ]);
+}

--- a/packages/cli/src/util/fsWatcher/implementations/__tests__/native.spec.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/__tests__/native.spec.ts
@@ -1,0 +1,57 @@
+import * as fs from 'node:fs/promises';
+import nativeWatchFs from '../native';
+import { mkdtempWithFiles } from './__helpers__/mkdtemp';
+import { race } from './__helpers__/race';
+
+describe('nativeWatchFs', () => {
+  describe.each(['dir', 'file'] as const)('given %s scope', scope => {
+    it.concurrent('should call the callback when a file changes', async () => {
+      const { files } = await mkdtempWithFiles();
+      const callback = jest.fn();
+      const controller = new AbortController();
+      const options = {
+        type: 'native',
+        scope,
+        signal: controller.signal,
+      } as const;
+
+      const watch = nativeWatchFs([files[0]], options, callback);
+
+      await fs.writeFile(files[0], 'new content');
+      try {
+        await race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[0]));
+      } finally {
+        controller.abort();
+      }
+
+      await expect(watch).resolves.toBeUndefined();
+    });
+
+    it.concurrent('should handle multiple paths', async () => {
+      const { files } = await mkdtempWithFiles();
+      const callback = jest.fn();
+      const controller = new AbortController();
+      const options = {
+        type: 'native',
+        scope,
+        signal: controller.signal,
+      } as const;
+
+      const watch = nativeWatchFs(files, options, callback);
+
+      try {
+        await Promise.all([
+          ...files.map(async file => fs.writeFile(file, 'new content')),
+          race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[0])),
+          race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[1])),
+          race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[2])),
+          race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[3])),
+        ]);
+      } finally {
+        controller.abort();
+      }
+
+      expect(watch).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/util/fsWatcher/implementations/__tests__/polling.spec.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/__tests__/polling.spec.ts
@@ -1,0 +1,71 @@
+import * as fs from 'node:fs/promises';
+import * as timers from 'node:timers/promises';
+import pollWatchFs from '../polling';
+import { mkdtempWithFiles } from './__helpers__/mkdtemp';
+import { race } from './__helpers__/race';
+
+describe('pollingWatchFs', () => {
+  it.concurrent('should call the callback when a file changes', async () => {
+    const { files } = await mkdtempWithFiles();
+    const callback = jest.fn();
+    const controller = new AbortController();
+    const options = {
+      type: 'polling',
+      interval: 50,
+      signal: controller.signal,
+    } as const;
+
+    pollWatchFs([files[0]], options, callback);
+
+    await fs.writeFile(files[0], 'new content');
+    try {
+      await race(150, controller, () => expect(callback).toHaveBeenCalledWith(files[0]));
+    } finally {
+      controller.abort();
+    }
+  });
+
+  it.concurrent('should handle multiple paths', async () => {
+    const { files } = await mkdtempWithFiles();
+    const callback = jest.fn();
+    const controller = new AbortController();
+    const options = {
+      type: 'polling',
+      interval: 100,
+      signal: controller.signal,
+    } as const;
+
+    pollWatchFs([files[0]], options, callback);
+
+    try {
+      await Promise.all([
+        ...files.map(async file => fs.writeFile(file, 'new content')),
+        race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[0])),
+        race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[1])),
+        race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[2])),
+        race(1000, controller, () => expect(callback).toHaveBeenCalledWith(files[3])),
+      ]);
+    } finally {
+      controller.abort();
+    }
+  });
+
+  it.concurrent('should respect signal', async () => {
+    const { files } = await mkdtempWithFiles();
+    const callback = jest.fn();
+    const controller = new AbortController();
+    const options = {
+      type: 'polling',
+      interval: 50,
+      signal: controller.signal,
+    } as const;
+
+    pollWatchFs([files[0]], options, callback);
+
+    controller.abort();
+    await fs.writeFile(files[0], 'new content');
+    await timers.setTimeout(150);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/util/fsWatcher/implementations/native.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/native.ts
@@ -10,7 +10,7 @@ async function nativeWatch(path: string, options: WatchOptions, callback: (event
       callback(event);
     }
   } catch (err) {
-    if (!(err instanceof Error) || err.name !== 'AbortError') {
+    if (typeof err !== 'object' || err === null || (err as { name?: string }).name !== 'AbortError') {
       throw err;
     }
   }
@@ -31,7 +31,6 @@ async function nativeWatchFsDir(paths: readonly string[], callback: Callback, op
     filesInDir.set(dir, new Set([path]));
     promises.push(
       nativeWatch(dir, options, event => {
-        if (event.eventType !== 'change') return;
         if (event.filename === null) return;
         const files = filesInDir.get(dir);
         const filepath = join(dir, event.filename);
@@ -50,10 +49,8 @@ async function nativeWatchFsFile(paths: readonly string[], callback: Callback, o
 
   for (const path of paths) {
     promises.push(
-      nativeWatch(path, options, event => {
-        if (event.eventType === 'change') {
-          callback(path);
-        }
+      nativeWatch(path, options, () => {
+        callback(path);
       })
     );
   }

--- a/packages/cli/src/util/fsWatcher/implementations/native.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/native.ts
@@ -1,0 +1,74 @@
+import type { WatchOptions } from 'node:fs';
+import { type FileChangeInfo, watch } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { Callback, FsWatchOptions } from '../types';
+
+async function nativeWatch(path: string, options: WatchOptions, callback: (event: FileChangeInfo<string>) => void) {
+  try {
+    const watcher = watch(path, options);
+    for await (const event of watcher) {
+      callback(event);
+    }
+  } catch (err) {
+    if (!(err instanceof Error) || err.name !== 'AbortError') {
+      throw err;
+    }
+  }
+}
+
+async function nativeWatchFsDir(paths: readonly string[], callback: Callback, options: WatchOptions) {
+  const filesInDir = new Map<string, Set<string>>();
+  const promises: Promise<void>[] = [];
+
+  for (const path of paths) {
+    const dir = dirname(path);
+    const files = filesInDir.get(dir);
+    if (files !== void 0) {
+      files.add(path);
+      continue;
+    }
+
+    filesInDir.set(dir, new Set([path]));
+    promises.push(
+      nativeWatch(dir, options, event => {
+        if (event.eventType !== 'change') return;
+        if (event.filename === null) return;
+        const files = filesInDir.get(dir);
+        const filepath = join(dir, event.filename);
+        if (files?.has(filepath)) {
+          callback(filepath);
+        }
+      })
+    );
+  }
+
+  await Promise.all(promises);
+}
+
+async function nativeWatchFsFile(paths: readonly string[], callback: Callback, options: WatchOptions) {
+  const promises: Promise<void>[] = [];
+
+  for (const path of paths) {
+    promises.push(
+      nativeWatch(path, options, event => {
+        if (event.eventType === 'change') {
+          callback(path);
+        }
+      })
+    );
+  }
+
+  await Promise.all(promises);
+}
+
+export default async function nativeWatchFs(
+  paths: readonly string[],
+  { scope, signal }: FsWatchOptions & { type: 'native' },
+  callback: Callback
+): Promise<void> {
+  if (scope === 'dir') {
+    return nativeWatchFsDir(paths, callback, { signal });
+  } else {
+    return nativeWatchFsFile(paths, callback, { signal });
+  }
+}

--- a/packages/cli/src/util/fsWatcher/implementations/polling.ts
+++ b/packages/cli/src/util/fsWatcher/implementations/polling.ts
@@ -1,0 +1,32 @@
+import { type StatsListener, unwatchFile, watchFile } from 'node:fs';
+
+import type { Callback, FsWatchOptions } from '../types';
+
+export default function pollWatchFs(
+  paths: readonly string[],
+  { signal, ...opts }: FsWatchOptions & { type: 'polling' },
+  callback: Callback
+) {
+  const listeners = new Map<string, StatsListener>();
+
+  for (const path of paths) {
+    const listener: StatsListener = (curr, prev) => {
+      if (curr.mtimeMs !== prev.mtimeMs) {
+        callback(path);
+      }
+    };
+
+    listeners.set(path, listener);
+    watchFile(path, opts, listener);
+  }
+
+  signal.addEventListener(
+    'abort',
+    () => {
+      for (const [path, listener] of listeners) {
+        unwatchFile(path, listener);
+      }
+    },
+    { once: true }
+  );
+}

--- a/packages/cli/src/util/fsWatcher/index.ts
+++ b/packages/cli/src/util/fsWatcher/index.ts
@@ -1,0 +1,23 @@
+import { isAbsolute, join } from 'node:path';
+import { debounceCallback } from './debounceCallback';
+import type { Callback, FsWatchOptions } from './types';
+import pollWatchFs from './implementations/polling';
+import nativeWatchFs from './implementations/native';
+
+export type { Callback, FsWatchOptions };
+
+export async function watchFs(
+  cwd: string,
+  paths: readonly string[],
+  options: FsWatchOptions,
+  callback: Callback
+): Promise<void> {
+  const debouncedCallback = debounceCallback(callback, options.signal);
+  const absolutePaths = paths.map(path => (isAbsolute(path) ? path : join(cwd, path)));
+
+  if (options.type === 'polling') {
+    pollWatchFs(absolutePaths, options, debouncedCallback);
+  } else {
+    await nativeWatchFs(absolutePaths, options, debouncedCallback);
+  }
+}

--- a/packages/cli/src/util/fsWatcher/types.ts
+++ b/packages/cli/src/util/fsWatcher/types.ts
@@ -1,0 +1,6 @@
+export type Callback = (path: string) => void;
+
+export type FsWatchOptions = ({ type: 'polling'; interval?: number } | { type: 'native'; scope: 'dir' | 'file' }) & {
+  signal: AbortSignal;
+};
+

--- a/packages/cli/src/web-locks.d.ts
+++ b/packages/cli/src/web-locks.d.ts
@@ -1,0 +1,4 @@
+declare module 'web-locks' {
+  export const locks: globalThis.LockManager;
+  export const AbortController: typeof globalThis.AbortController;
+}

--- a/packages/http/src/__tests__/memory-leak-prevention.spec.ts
+++ b/packages/http/src/__tests__/memory-leak-prevention.spec.ts
@@ -35,11 +35,11 @@ describe('Checks if memory leaks', () => {
     for (let i = 0; i < 5000; i++) {
       round(client);
       if (i % 100 === 0) {
-        global.gc();
+        global.gc!();
       }
     }
 
-    global.gc();
+    global.gc!();
     expect(process.memoryUsage().heapUsed).toBeLessThanOrEqual(baseMemoryUsage * 1.03);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,10 +1421,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^13.1.1":
-  version "13.13.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
-  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+"@types/node@^22.9.4":
+  version "22.10.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.5.tgz#95af89a3fb74a2bb41ef9927f206e6472026e48b"
+  integrity sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==
+  dependencies:
+    undici-types "~6.20.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -1791,7 +1793,7 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-anymatch@^3.0.3, anymatch@~3.1.2:
+anymatch@^3.0.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -1973,11 +1975,6 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -2007,7 +2004,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.2, braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2206,21 +2203,6 @@ charset@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz"
   integrity sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==
-
-chokidar@^3.5.2:
-  version "3.5.3"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -3429,7 +3411,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -3587,7 +3569,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@5.1.2, glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@5.1.2, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -4047,13 +4029,6 @@ is-bigint@^1.0.1:
   dependencies:
     has-bigints "^1.0.1"
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz"
@@ -4108,7 +4083,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5655,7 +5630,7 @@ normalize-package-data@^6.0.0:
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -6211,7 +6186,7 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -6614,13 +6589,6 @@ readable-stream@~2.3.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -7571,6 +7539,11 @@ undici-types@~5.26.4:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
 unique-filename@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea"
@@ -7739,6 +7712,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-locks@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/web-locks/-/web-locks-0.0.8.tgz#17e1704ab6122e69e0fdb5824e65fea5b4e30090"
+  integrity sha512-4K1HUuu9EjougZiaX3RQcR862nTaHwxpD9yJ+6dHXosw3L5MnFD8a8CJaN+AoP9IqhKYShMMc7efJF23/KGF/g==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
**Summary**

This makes fs watching optional and introduces different modes, with `polling` being the default.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A


