### PR TITLE
Improve circular refs handling

### DIFF
--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -11,7 +11,7 @@ jest.mock('../../util/createServer', () => ({
   createSingleProcessPrism: jest.fn().mockResolvedValue([]),
 }));
 
-jest.spyOn(operationUtils, 'getHttpOperationsFromSpec').mockResolvedValue([]);
+jest.spyOn(operationUtils, 'getHttpOperationsFromSpec').mockReturnValue([]);
 
 describe.each<{ 0: string; 1: string; 2: unknown }>([
   ['mock', '', { dynamic: false }],

--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -1,17 +1,13 @@
-import * as $RefParser from '@stoplight/json-schema-ref-parser';
-import { decycle } from '@stoplight/json';
 import { get, camelCase, forOwn } from 'lodash';
 import { JSONSchemaFaker } from 'json-schema-faker';
 import type { JSONSchemaFakerOptions } from 'json-schema-faker';
 import { resetJSONSchemaGenerator } from '@stoplight/prism-http';
 import { type Observable, observeAll } from './util/observable';
 
-export async function configureExtensionsUserProvided(
-  specFilePathOrObject: string | object,
+export function configureExtensionsUserProvided(
+  result: Record<string, unknown>,
   cliParamOptions: Observable<JSONSchemaFakerOptions>
-): Promise<void> {
-  const result = decycle(await new $RefParser().dereference(specFilePathOrObject));
-
+): void {
   resetJSONSchemaGenerator();
 
   observeAll(cliParamOptions, key => {

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -18,6 +18,7 @@ import { attachTagsToParamsValues, transformPathParamsValues } from './colorizer
 import { configureExtensionsUserProvided } from '../extensions';
 import type { JSONSchemaFakerOptions } from 'json-schema-faker';
 import { type Observable, observable, observe } from './observable';
+import { readDocument } from './readDocument';
 
 const cluster = require('cluster') as typeof import('cluster').default;
 
@@ -75,7 +76,8 @@ const createSingleProcessPrism: CreatePrism = options => {
 };
 
 async function createPrismServerWithLogger(options: Observable<CreateBaseServerOptions>, logInstance: pino.Logger) {
-  const operations = await getHttpOperationsFromSpec(options.document);
+  const document = await readDocument(options.document);
+  const operations = getHttpOperationsFromSpec(document);
   if (operations.length === 0) {
     throw new Error('No operations found in the current file.');
   }
@@ -87,7 +89,7 @@ async function createPrismServerWithLogger(options: Observable<CreateBaseServerO
     jsonSchemaFakerCliParams.fillProperties = options.jsonSchemaFakerFillProperties;
   });
 
-  await configureExtensionsUserProvided(options.document, jsonSchemaFakerCliParams);
+  configureExtensionsUserProvided(document, jsonSchemaFakerCliParams);
 
   const validateRequest = isProxyServerOptions(options) ? options.validateRequest : true;
   const shared = {

--- a/packages/cli/src/util/readDocument.ts
+++ b/packages/cli/src/util/readDocument.ts
@@ -1,0 +1,13 @@
+import * as os from 'node:os';
+import * as $RefParser from '@stoplight/json-schema-ref-parser';
+import { getSpec } from '@stoplight/prism-http';
+
+export function readDocument(filepath: string): Promise<Record<string, unknown>> {
+  const { version: prismVersion } = require('../../package.json');
+  const httpResolverOpts: $RefParser.HTTPResolverOptions = {
+    headers: {
+      'User-Agent': `PrismMockServer/${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
+    },
+  };
+  return getSpec(filepath, { resolve: { http: httpResolverOpts } });
+}

--- a/packages/cli/src/util/runner.ts
+++ b/packages/cli/src/util/runner.ts
@@ -7,6 +7,7 @@ import { getHttpOperationsFromSpec } from '@stoplight/prism-http';
 import { safeApplyConfig } from './config';
 import { disposeHandlers, type Observable, observable } from './observable';
 import { type FsWatchOptions, watchFs } from './fsWatcher/index';
+import { readDocument } from './readDocument';
 
 export type CreatePrism = (options: Observable<CreateMockServerOptions>) => Promise<IPrismHttpServer | void>;
 
@@ -62,7 +63,7 @@ export async function runPrismAndSetupWatcher(
       disposeHandlers(observableOptions);
 
       try {
-        const operations = await getHttpOperationsFromSpec(observableOptions.document);
+        const operations = getHttpOperationsFromSpec(await readDocument(observableOptions.document));
         if (operations.length === 0) {
           server.logger.info('No operations found in the current file, continuing with the previously loaded spec.');
         } else {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@stoplight/prism-core';
-import { getHttpOperationsFromSpec } from '@stoplight/prism-http';
+import { getHttpOperationsFromSpec, getSpec } from '@stoplight/prism-http';
 import { IHttpConfig, IHttpMockConfig } from '@stoplight/prism-http';
 import { resolve } from 'path';
 import { merge } from 'lodash';
@@ -22,7 +22,7 @@ function checkErrorPayloadShape(payload: string) {
 }
 
 async function instantiatePrism(specPath: string, configOverride?: Partial<IHttpConfig>) {
-  const operations = await getHttpOperationsFromSpec(specPath);
+  const operations = getHttpOperationsFromSpec(await getSpec(specPath));
   const server = createServer(operations, {
     components: { logger },
     config: merge<IHttpMockConfig, Partial<IHttpConfig> | undefined>(

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -4,7 +4,8 @@ import { Scope as NockScope } from 'nock';
 import * as nock from 'nock';
 import { basename, resolve } from 'path';
 import { createInstance, IHttpProxyConfig, IHttpRequest, IHttpResponse, ProblemJsonError } from '../';
-import { getHttpOperationsFromSpec } from '../';
+import { getHttpOperationsFromSpec } from '../utils/operations';
+import { getSpec } from '../utils/getSpec';
 import { UNPROCESSABLE_ENTITY } from '../mocker/errors';
 import { NO_PATH_MATCHED_ERROR, NO_SERVER_MATCHED_ERROR } from '../router/errors';
 import { assertResolvesRight, assertResolvesLeft } from '@stoplight/prism-core/src/__tests__/utils';
@@ -69,7 +70,7 @@ describe('Http Client .request', () => {
         },
         { logger }
       );
-      resources = await getHttpOperationsFromSpec(specPath);
+      resources = getHttpOperationsFromSpec(await getSpec(specPath));
     });
 
     describe('baseUrl not set', () => {
@@ -243,7 +244,7 @@ describe('Http Client .request', () => {
         },
         { logger }
       );
-      resources = await getHttpOperationsFromSpec(noRefsPetstoreMinimalOas2Path);
+      resources = getHttpOperationsFromSpec(await getSpec(noRefsPetstoreMinimalOas2Path));
     });
 
     describe('path is invalid', () => {
@@ -357,8 +358,10 @@ describe('Http Client .request', () => {
       ));
   });
 
-  it('loads spec provided in yaml', () => {
-    return expect(getHttpOperationsFromSpec(petStoreOas2Path)).resolves.toHaveLength(3);
+  it('loads spec provided in yaml', async () => {
+    const result = getSpec(petStoreOas2Path);
+    await expect(result).resolves.toBeTruthy();
+    expect(getHttpOperationsFromSpec(await result)).toHaveLength(3)
   });
 
   it('returns stringified static example when one defined in spec', async () => {
@@ -374,7 +377,7 @@ describe('Http Client .request', () => {
       },
       { logger }
     );
-    resources = await getHttpOperationsFromSpec(staticExamplesOas2Path);
+    resources = getHttpOperationsFromSpec(await getSpec(staticExamplesOas2Path));
 
     return assertResolvesRight(
       prism.request(
@@ -419,7 +422,7 @@ describe('proxy server', () => {
         { logger }
       );
 
-      const resources = await getHttpOperationsFromSpec(petStoreOas2Path);
+      const resources = getHttpOperationsFromSpec(await getSpec(petStoreOas2Path));
       return assertResolvesRight(prism.request({ method: 'get', url: { path: '/pets' } }, resources), response => {
         expect(response.output.statusCode).toBe(200);
         expect(response.output.body).toBe('<html><h1>Hello</h1>');
@@ -447,7 +450,7 @@ describe('proxy server', () => {
     );
 
     it('returns stringified static example when one defined in spec', async () => {
-      const resources = await getHttpOperationsFromSpec(staticExamplesOas2Path);
+      const resources = getHttpOperationsFromSpec(await getSpec(staticExamplesOas2Path));
 
       return assertResolvesRight(prism.request({ method: 'get', url: { path: '/todos' } }, resources), response => {
         expect(response.output).toBeDefined();
@@ -470,7 +473,7 @@ describe('proxy server', () => {
         },
         { logger }
       );
-      const resources = await getHttpOperationsFromSpec(dynamicGenerationOas3Path);
+      const resources =  getHttpOperationsFromSpec(await getSpec(dynamicGenerationOas3Path));
       const headers = {
         prefer: 'dynamic=true',
       };
@@ -499,7 +502,7 @@ describe('proxy server', () => {
         },
         { logger }
       );
-      const resources = await getHttpOperationsFromSpec(dynamicGenerationOas3Path);
+      const resources = getHttpOperationsFromSpec(await getSpec(dynamicGenerationOas3Path));
       const headers = {
         Prefer: 'example=Example2',
       };

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -13,6 +13,7 @@ export { generate as generateHttpParam } from './mocker/generator/HttpParamGener
 export { resetJSONSchemaGenerator } from './mocker';
 import { IHttpConfig, IHttpResponse, IHttpRequest, PickRequired, PrismHttpComponents, IHttpProxyConfig } from './types';
 export { getHttpOperationsFromSpec } from './utils/operations';
+export { getSpec } from './utils/getSpec';
 export { createAndCallPrismInstanceWithSpec, PrismErrorResult, PrismOkResult } from './instanceWithSpec';
 
 export const createInstance = (

--- a/packages/http/src/instanceWithSpec.ts
+++ b/packages/http/src/instanceWithSpec.ts
@@ -5,6 +5,7 @@ import type { Logger } from 'pino';
 import { pipe } from 'fp-ts/function';
 import { isRight, isLeft } from 'fp-ts/lib/Either';
 import { IPrismOutput } from '@stoplight/prism-core';
+import { getSpec } from './utils/getSpec';
 
 export type PrismOkResult = {
   result: 'ok';
@@ -22,7 +23,7 @@ export async function createAndCallPrismInstanceWithSpec(
   request: IHttpRequest,
   logger: Logger
 ): Promise<PrismErrorResult | PrismOkResult> {
-  const operations = await getHttpOperationsFromSpec(spec);
+  const operations = getHttpOperationsFromSpec(await getSpec(spec));
   const prism = createInstance(options, { logger });
   const result = await pipe(prism.request(request, operations))();
   if (isRight(result)) {

--- a/packages/http/src/utils/__tests__/getSpec.spec.ts
+++ b/packages/http/src/utils/__tests__/getSpec.spec.ts
@@ -1,0 +1,24 @@
+import { getSpec } from '../getSpec';
+
+describe('getSpec()', () => {
+  describe('ref resolving fails', () => {
+    it('fails with exception', () => {
+      return expect(
+        getSpec({
+          openapi: '3.0.0',
+          paths: { $ref: 'abc://' },
+        })
+      ).rejects.toThrow('Unable to resolve $ref pointer "abc://"');
+    });
+
+    it('deduplicates similar errors', () => {
+      return expect(
+        getSpec({
+          openapi: '3.0.0',
+          paths: { $ref: 'abc://' },
+          definitions: { $ref: 'abc://' },
+        })
+      ).rejects.toThrow('Unable to resolve $ref pointer "abc://"');
+    });
+  });
+});

--- a/packages/http/src/utils/__tests__/operations.spec.ts
+++ b/packages/http/src/utils/__tests__/operations.spec.ts
@@ -1,75 +1,52 @@
 import { getHttpOperationsFromSpec } from '../operations';
 
 describe('getHttpOperationsFromSpec()', () => {
-  describe('ref resolving fails', () => {
-    it('fails with exception', () => {
-      return expect(
-        getHttpOperationsFromSpec({
-          openapi: '3.0.0',
-          paths: { $ref: 'abc://' },
-        })
-      ).rejects.toThrow('Unable to resolve $ref pointer "abc://"');
-    });
-
-    it('deduplicates similar errors', () => {
-      return expect(
-        getHttpOperationsFromSpec({
-          openapi: '3.0.0',
-          paths: { $ref: 'abc://' },
-          definitions: { $ref: 'abc://' },
-        })
-      ).rejects.toThrow('Unable to resolve $ref pointer "abc://"');
+  describe('OpenAPI 2 document is provided', () => {
+    it('detects it properly', () => {
+      expect(getHttpOperationsFromSpec({ swagger: '2.0' })).toBeTruthy();
     });
   });
 
-  describe('ref resolving succeeds', () => {
-    describe('OpenAPI 2 document is provided', () => {
-      it('detects it properly', () => {
-        return expect(getHttpOperationsFromSpec({ swagger: '2.0' })).resolves.toBeTruthy();
-      });
+  describe('OpenAPI 3 document is provided', () => {
+    it('detects it properly', () => {
+      expect(getHttpOperationsFromSpec({ openapi: '3.0.0' })).toBeTruthy();
     });
 
-    describe('OpenAPI 3 document is provided', () => {
-      it('detects it properly', () => {
-        return expect(getHttpOperationsFromSpec({ openapi: '3.0.0' })).resolves.toBeTruthy();
-      });
-
-      it('returns correct HttpOperation', () => {
-        return expect(
-          getHttpOperationsFromSpec({
-            openapi: '3.0.0',
-            paths: {
-              '/pet': { get: { responses: { 200: { description: 'test' } } } },
+    it('returns correct HttpOperation', () => {
+      expect(
+        getHttpOperationsFromSpec({
+          openapi: '3.0.0',
+          paths: {
+            '/pet': { get: { responses: { 200: { description: 'test' } } } },
+          },
+        })
+      ).toEqual([
+        expect.objectContaining({
+          method: 'get',
+          path: '/pet',
+          responses: [
+            {
+              id: expect.any(String),
+              code: '200',
+              contents: [],
+              description: 'test',
+              headers: [],
             },
-          })
-        ).resolves.toEqual([
-          expect.objectContaining({
-            method: 'get',
-            path: '/pet',
-            responses: [
-              {
-                id: expect.any(String),
-                code: '200',
-                contents: [],
-                description: 'test',
-                headers: [],
-              },
-            ],
-          }),
-        ]);
-      });
+          ],
+        }),
+      ]);
     });
+  });
 
-    describe('Postman Collection document is provided', () => {
-      it('detects it properly', () => {
-        return expect(getHttpOperationsFromSpec({ info: { name: 'Test' }, item: [] })).resolves.toBeTruthy();
-      });
+  describe('Postman Collection document is provided', () => {
+    it('detects it properly', () => {
+      expect(getHttpOperationsFromSpec({ info: { name: 'Test' }, item: [] })).toBeTruthy();
     });
+  });
 
-    describe('unknown document is provided', () => {
-      it('throws error', () => {
-        return expect(getHttpOperationsFromSpec({})).rejects.toThrow(/^Unsupported document format$/);
-      });
+  describe('unknown document is provided', () => {
+    it('throws error', () => {
+      expect(getHttpOperationsFromSpec.bind(null, {})).toThrow(/^Unsupported document format$/);
     });
   });
 });

--- a/packages/http/src/utils/getSpec.ts
+++ b/packages/http/src/utils/getSpec.ts
@@ -1,0 +1,14 @@
+import { isPlainObject } from '@stoplight/json';
+import * as $RefParser from '@stoplight/json-schema-ref-parser';
+
+export async function getSpec(
+  specFilePathOrObject: string | object,
+  options: $RefParser.Options = {}
+): Promise<Record<string, unknown>> {
+  const result = await new $RefParser().bundle(specFilePathOrObject, options);
+  if (!isPlainObject(result)) {
+    throw new Error('Unsupported document format');
+  }
+
+  return result;
+}

--- a/packages/http/src/utils/operations.ts
+++ b/packages/http/src/utils/operations.ts
@@ -1,27 +1,14 @@
 import { transformOas3Operations } from '@stoplight/http-spec/oas3/operation';
 import { transformOas2Operations } from '@stoplight/http-spec/oas2/operation';
 import { transformPostmanCollectionOperations } from '@stoplight/http-spec/postman/operation';
-import * as $RefParser from '@stoplight/json-schema-ref-parser';
-import { HTTPResolverOptions } from '@stoplight/json-schema-ref-parser';
-import { bundleTarget, decycle } from '@stoplight/json';
+import { bundleTarget } from '@stoplight/json';
 import { IHttpOperation } from '@stoplight/types';
 import { get } from 'lodash';
-import * as os from 'os';
 import type { Spec } from 'swagger-schema-official';
 import type { OpenAPIObject } from 'openapi3-ts';
 import type { CollectionDefinition } from 'postman-collection';
 
-export async function getHttpOperationsFromSpec(specFilePathOrObject: string | object): Promise<IHttpOperation[]> {
-  const prismVersion = require('../../package.json').version;
-  const httpResolverOpts: HTTPResolverOptions = {
-    headers: {
-      'User-Agent': `PrismMockServer/${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
-    },
-  };
-  const result = decycle(
-    await new $RefParser().dereference(specFilePathOrObject, { resolve: { http: httpResolverOpts } })
-  );
-
+export function getHttpOperationsFromSpec(result: Record<string, unknown>): IHttpOperation[] {
   let operations: IHttpOperation[] = [];
   if (isOpenAPI2(result)) operations = transformOas2Operations(result);
   else if (isOpenAPI3(result)) operations = transformOas3Operations(result);
@@ -30,10 +17,12 @@ export async function getHttpOperationsFromSpec(specFilePathOrObject: string | o
 
   operations.forEach((op, i, ops) => {
     ops[i] = bundleTarget({
-      document: {
-        ...result,
-        __target__: op,
-      },
+      document: JSON.parse(
+        JSON.stringify({
+          ...result,
+          __target__: op,
+        })
+      ),
       path: '#/__target__',
       cloneDocument: false,
     });

--- a/test-harness/specs/references/E2E-Recursive-Array-Handling.oas3.1.txt
+++ b/test-harness/specs/references/E2E-Recursive-Array-Handling.oas3.1.txt
@@ -42,4 +42,4 @@ curl -i http://localhost:4010/
 ====expect====
 HTTP/1.1 200 OK
 
-{"prop":{"text":"string","type":"string","metadata":{},"children":[{"text":"string","type":"string","metadata":{},"children":[{}]}]}}
+{"prop":{"text":"string","type":"string","metadata":{},"children":[{}]}}

--- a/test-harness/specs/references/E2E-Recursive-Array-Handling.oas3.txt
+++ b/test-harness/specs/references/E2E-Recursive-Array-Handling.oas3.txt
@@ -42,4 +42,4 @@ curl -i http://localhost:4010/
 ====expect====
 HTTP/1.1 200 OK
 
-{"prop":{"text":"string","type":"string","metadata":{},"children":[{"text":"string","type":"string","metadata":{},"children":[{}]}]}}
+{"prop":{"text":"string","type":"string","metadata":{},"children":[{}]}}


### PR DESCRIPTION
Addresses https://datawire.slack.com/archives/C01PUJXR6CT/p1738607830906789

**Summary**

We already had code in place for rebundling in `getHttpOperationsFromSpec` function, so I made an effective use of that (on a side note - this code was pretty much no-op as things stood, the only thing it did was rewriting the top-level refs)
I considered using deference with `circular="ignore"`, but the results were rather similar as far as the negotiated content is concerned (arguably the output prior to this change was slightly better for circular structures, as we kept at least a single copy and then left a hole). That said, I might still change it to that, as it's likely to be faster.

I tried not to touch [json-schema-ref-parser](https://github.com/stoplightio/json-schema-ref-parser) (to avoid needing to fork it), but I'll have a look at some point.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

