### PR TITLE
feat(http): use smarter bundling

### DIFF
--- a/packages/http/src/utils/__tests__/__fixtures__/schema-refs.oas3.yaml
+++ b/packages/http/src/utils/__tests__/__fixtures__/schema-refs.oas3.yaml
@@ -1,0 +1,316 @@
+---
+openapi: 3.0.0
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about     Swagger
+    at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For
+    this sample, you can use the api key `special-key` to test the authorization     filters.'
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  "/pets":
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  "/pets/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            $ref: "#/components/schemas/Id"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '418':
+          description: teapot response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                required:
+                  - id
+                  - code
+                  - message
+                properties:
+                  id:
+                    $ref: "#/components/schemas/Id"
+                  code:
+                    type: integer
+                    format: int32
+                  message:
+                    type: string
+      security:
+        - api_key: []
+    put:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            $ref: "#/components/schemas/Id"
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore.swagger.io/v2
+  - url: http://petstore.swagger.io/v2
+components:
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              "$ref": "#/components/schemas/User"
+      description: List of user object
+      required: true
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Id:
+      type: integer
+      format: int64
+    Order:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        petId:
+          $ref: "#/components/schemas/Id"
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet

--- a/packages/http/src/utils/__tests__/bundleHttpOperation.spec.ts
+++ b/packages/http/src/utils/__tests__/bundleHttpOperation.spec.ts
@@ -1,0 +1,125 @@
+import { join } from 'node:path';
+import * as $RefParser from '@stoplight/json-schema-ref-parser';
+import { transformOas3Operation } from '@stoplight/http-spec/oas3';
+import { getSpec } from '../getSpec';
+import { bundleHttpOperation } from '../bundleHttpOperation';
+import type { IHttpOperation } from '@stoplight/types';
+
+describe('bundleHttpOperation', () => {
+  let schemaRefsDocument: Record<string, unknown>;
+
+  beforeAll(async () => {
+    schemaRefsDocument = await getSpec(join(__dirname, '__fixtures__/schema-refs.oas3.yaml'));
+  });
+
+  it.each(['POST /pets', 'PUT /pets', 'GET /pets/{petId}', 'PUT /pets/{petId}', 'DELETE /pets/{petId}'])(
+    'given %s, resects refs in a http operation',
+    async op => {
+      const [method, path] = op.split(' ');
+      const operation = transformOas3Operation({
+        document: schemaRefsDocument,
+        name: path,
+        method: method.toLowerCase(),
+        config: {
+          type: 'operation',
+          documentProp: 'paths',
+          nameProp: 'path',
+        },
+      });
+
+      bundleHttpOperation(JSON.parse(JSON.stringify(schemaRefsDocument)), operation as IHttpOperation<false>);
+      await expect($RefParser.dereference(operation)).resolves.toMatchObject({
+        path,
+        method: method.toLowerCase(),
+      });
+    }
+  );
+
+  it('should contextify schema object', async () => {
+    const operation = transformOas3Operation({
+      document: schemaRefsDocument,
+      name: '/pets/{petId}',
+      method: 'get',
+      config: {
+        type: 'operation',
+        documentProp: 'paths',
+        nameProp: 'path',
+      },
+    });
+
+    bundleHttpOperation(JSON.parse(JSON.stringify(schemaRefsDocument)), operation as IHttpOperation<false>);
+    await expect(
+      $RefParser.dereference(operation.responses[0].contents![0].schema as $RefParser.JSONSchema)
+    ).resolves.toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+          format: 'int64',
+        },
+        category: {
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+            },
+            name: {
+              type: 'string',
+            },
+          },
+          type: 'object',
+          xml: {
+            name: 'Category',
+          },
+        },
+        name: {
+          type: 'string',
+          examples: ['doggie'],
+        },
+        photoUrls: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          xml: {
+            name: 'photoUrl',
+            wrapped: true,
+          },
+        },
+        status: {
+          description: 'pet status in the store',
+          enum: ['available', 'pending', 'sold'],
+          type: 'string',
+        },
+        tags: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+              },
+              name: {
+                type: 'string',
+              },
+            },
+            xml: {
+              name: 'Tag',
+            },
+          },
+          xml: {
+            name: 'tag',
+            wrapped: true,
+          },
+        },
+      },
+      required: ['name', 'photoUrls'],
+      'x-stoplight': expect.anything(),
+      xml: {
+        name: 'Pet',
+      },
+    });
+  });
+});

--- a/packages/http/src/utils/__tests__/traverseSchema.spec.ts
+++ b/packages/http/src/utils/__tests__/traverseSchema.spec.ts
@@ -1,0 +1,92 @@
+import { traverseSchema } from '../traverseSchema';
+
+describe('traverseSchema', () => {
+  it('calls callback for root schema', () => {
+    const schema = { type: 'object' };
+    const callback = jest.fn();
+    traverseSchema(schema, callback);
+    expect(callback).toHaveBeenCalledWith(schema);
+  });
+
+  it('calls callback for nested schemas', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        propertyNames: {
+          type: 'string',
+          pattern: '^[a-z]+$',
+        },
+      },
+    };
+    const callback = jest.fn();
+    traverseSchema(schema, callback);
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(callback).nthCalledWith(2, schema.additionalProperties);
+    expect(callback).nthCalledWith(3, schema.additionalProperties.propertyNames);
+  });
+
+  it('does not call callback for boolean schemas', () => {
+    const schema = {
+      type: 'object',
+      unevaluatedProperties: false,
+      properties: {
+        name: false,
+        address: true,
+      },
+    };
+    const callback = jest.fn();
+    traverseSchema(schema, callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls callback for nested keyed schemas ', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        address: {
+          type: 'object',
+          properties: { street: { type: 'string' } },
+        },
+        countries: {
+          patternProperties: {
+            '^\\d{3}$': { type: 'string' },
+          },
+        },
+      },
+    };
+    const callback = jest.fn();
+    traverseSchema(schema, callback);
+    expect(callback).toHaveBeenCalledTimes(6);
+    expect(callback).nthCalledWith(2, schema.properties.name);
+    expect(callback).nthCalledWith(3, schema.properties.address);
+    expect(callback).nthCalledWith(4, schema.properties.address.properties.street);
+    expect(callback).nthCalledWith(5, schema.properties.countries);
+    expect(callback).nthCalledWith(6, schema.properties.countries['patternProperties']['^\\d{3}$']);
+  });
+
+  it.each(['anyOf', 'oneOf', 'allOf'])('calls callback for compound schemas', keyword => {
+    const schema = {
+      [keyword]: [
+        {
+          type: 'object',
+          properties: {
+            name: false,
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            address: true,
+          },
+        },
+      ],
+    };
+    const callback = jest.fn();
+    traverseSchema(schema, callback);
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(callback).nthCalledWith(2, schema[keyword][0]);
+    expect(callback).nthCalledWith(3, schema[keyword][1]);
+  });
+});

--- a/packages/http/src/utils/bundleHttpOperation.ts
+++ b/packages/http/src/utils/bundleHttpOperation.ts
@@ -1,0 +1,166 @@
+import type {
+  IHttpEncoding,
+  IHttpContent,
+  IHttpOperation,
+  IHttpOperationRequest,
+  IHttpOperationResponse,
+} from '@stoplight/types';
+import { traverseSchema } from './traverseSchema';
+import { hasRef, isPlainObject, resolveInlineRef } from '@stoplight/json';
+
+// the date is used to minimize the risk of a collision
+// we cannot use a symbol for a property key as this key is included in a JSON pointer
+const ROOT_KEY = `__root__-${Date.now()}`;
+
+// this function is used to bundle the HTTP operation
+// it mutates the operation object in place, and only touches objects that may have some references
+// which in reality is only schema objects as the non-bundled http operation would have all other references resolved as this point
+export function bundleHttpOperation(document: Record<string, unknown>, operation: IHttpOperation<false>): void {
+  const { responses, request, callbacks } = operation;
+  // the key must be non-enumerable
+  Object.defineProperty(operation, ROOT_KEY, { value: document });
+
+  if (isDefined(request)) {
+    bundleHttpOperationRequest(document, request);
+  }
+
+  if (isDefined(responses)) {
+    for (const response of responses) {
+      bundleHttpOperationResponse(document, response);
+    }
+  }
+
+  if (isDefined(callbacks)) {
+    for (const callback of callbacks) {
+      for (const callbackOperation of Object.values(callback)) {
+        bundleHttpOperation(document, callbackOperation);
+      }
+    }
+  }
+}
+
+function bundleHttpContent(document: Record<string, unknown>, { encodings, schema }: IHttpContent<false>): void {
+  if (isDefined(schema)) {
+    bundleSchemaObject(document, schema as Record<string, unknown>);
+  }
+
+  if (isDefined(encodings)) {
+    for (const encoding of encodings) {
+      bundleHttpEncoding(document, encoding);
+    }
+  }
+}
+
+function bundleHttpEncoding(document: Record<string, unknown>, { headers }: IHttpEncoding<false>): void {
+  if (isDefined(headers)) {
+    for (const header of headers) {
+      bundleHttpContent(document, header);
+    }
+  }
+}
+
+function bundleHttpOperationRequest(
+  document: Record<string, unknown>,
+  { body, headers, path, cookie, query }: IHttpOperationRequest<false>
+): void {
+  if (isDefined(body) && isDefined(body.contents)) {
+    for (const content of body.contents) {
+      bundleHttpContent(document, content);
+    }
+  }
+
+  for (const params of [headers, path, cookie, query]) {
+    if (!isDefined(params)) continue;
+    for (const param of params) {
+      bundleHttpContent(document, param);
+    }
+  }
+
+  return;
+}
+
+function bundleHttpOperationResponse(
+  document: Record<string, unknown>,
+  { contents, headers }: IHttpOperationResponse<false>
+): void {
+  if (isDefined(contents)) {
+    for (const content of contents) {
+      bundleHttpContent(document, content);
+    }
+  }
+
+  if (isDefined(headers)) {
+    for (const header of headers) {
+      bundleHttpContent(document, header);
+    }
+  }
+}
+
+function bundleSchemaObject(document: Record<string, unknown>, object: Record<string, unknown>): void {
+  // if we can't set the descriptor,
+  // the value must have been already mutated earlier by us,
+  // and we can safely skip it
+  if (!Reflect.defineProperty(object, ROOT_KEY, { value: document })) {
+    return;
+  }
+
+  const traversed = new WeakSet<Record<string, unknown>>();
+  const processedRefs = new Set<string>();
+  const seen = new Set<Record<string, unknown>>();
+
+  bundleSchema(
+    {
+      traversed,
+      processedRefs,
+      seen,
+    },
+    document,
+    object
+  );
+}
+
+function bundleSchema(
+  ctx: {
+    readonly traversed: WeakSet<Record<string, unknown>>;
+    readonly processedRefs: Set<string>;
+    readonly seen: Set<Record<string, unknown>>;
+  },
+  document: Record<string, unknown>,
+  object: Record<string, unknown>
+) {
+  const { traversed, processedRefs, seen } = ctx;
+  traverseSchema(object, schema => {
+    traversed.add(schema);
+    if (!hasRef(schema)) return;
+
+    const $ref = schema.$ref;
+    schema.$ref = rewriteRef($ref);
+    if (schema.$ref === $ref) return;
+    if (processedRefs.has($ref)) return;
+
+    processedRefs.add($ref);
+    const resolved = resolveInlineRef(document, $ref);
+    if (isPlainObject(resolved)) {
+      seen.add(resolved);
+    }
+  });
+
+  for (const schema of seen) {
+    if (traversed.has(schema)) continue;
+    traversed.add(schema);
+
+    traverseSchema(schema, schema => {
+      bundleSchema(ctx, document, schema);
+    });
+  }
+
+  return object;
+}
+
+function rewriteRef(value: string) {
+  return `#/${ROOT_KEY}${value.slice(1).replace(`/${ROOT_KEY}/`, '/')}`;
+}
+
+function isDefined(value: unknown): value is NonNullable<typeof value> {
+  return value !== void 0;
+}

--- a/packages/http/src/utils/operations.ts
+++ b/packages/http/src/utils/operations.ts
@@ -1,32 +1,23 @@
 import { transformOas3Operations } from '@stoplight/http-spec/oas3/operation';
 import { transformOas2Operations } from '@stoplight/http-spec/oas2/operation';
 import { transformPostmanCollectionOperations } from '@stoplight/http-spec/postman/operation';
-import { bundleTarget } from '@stoplight/json';
 import { IHttpOperation } from '@stoplight/types';
 import { get } from 'lodash';
 import type { Spec } from 'swagger-schema-official';
 import type { OpenAPIObject } from 'openapi3-ts';
 import type { CollectionDefinition } from 'postman-collection';
+import { bundleHttpOperation } from './bundleHttpOperation';
 
 export function getHttpOperationsFromSpec(result: Record<string, unknown>): IHttpOperation[] {
-  let operations: IHttpOperation[] = [];
+  let operations: IHttpOperation[];
   if (isOpenAPI2(result)) operations = transformOas2Operations(result);
   else if (isOpenAPI3(result)) operations = transformOas3Operations(result);
   else if (isPostmanCollection(result)) operations = transformPostmanCollectionOperations(result);
   else throw new Error('Unsupported document format');
 
-  operations.forEach((op, i, ops) => {
-    ops[i] = bundleTarget({
-      document: JSON.parse(
-        JSON.stringify({
-          ...result,
-          __target__: op,
-        })
-      ),
-      path: '#/__target__',
-      cloneDocument: false,
-    });
-  });
+  for (const operation of operations) {
+    bundleHttpOperation(result, operation);
+  }
 
   return operations;
 }

--- a/packages/http/src/utils/traverseSchema.ts
+++ b/packages/http/src/utils/traverseSchema.ts
@@ -1,0 +1,45 @@
+import { isPlainObject } from '@stoplight/json';
+
+const keywords = new Set([
+  'additionalItems',
+  'unevaluatedItems',
+  'items',
+  'contains',
+
+  'additionalProperties',
+  'unevaluatedProperties',
+  'propertyNames',
+
+  'not',
+  'if',
+  'then',
+  'else',
+] as const);
+
+const arrayishKeywords = new Set(['items', 'prefixItems', 'allOf', 'anyOf', 'oneOf'] as const);
+
+const propsKeywords = new Set(['properties', 'patternProperties', 'dependencies', 'dependentSchemas'] as const);
+
+function hasKeyword(set: Set<string>, keyword: string) {
+  return set.has(keyword);
+}
+
+export function traverseSchema(schema: Record<string, unknown>, callback: (schema: Record<string, unknown>) => void) {
+  callback(schema);
+
+  for (const [keyword, value] of Object.entries(schema)) {
+    if (hasKeyword(keywords, keyword) && isPlainObject(value)) {
+      traverseSchema(value, callback);
+    } else if (hasKeyword(arrayishKeywords, keyword) && Array.isArray(value)) {
+      for (const item of value) {
+        traverseSchema(item, callback);
+      }
+    } else if (hasKeyword(propsKeywords, keyword) && isPlainObject(value)) {
+      for (const prop of Object.values(value)) {
+        if (isPlainObject(prop)) {
+          traverseSchema(prop, callback);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Summary**

This pull request includes several changes to the `packages/http` module to support more performant bundling.
It exploits the today's behavior of http-spec, and the tooling used today, and is strictly tailored to them.
Some changes were needed to generators in `packages/http/src/mocker/generator/JSONSchema.ts` to properly persist the non-enumerable property.


**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

